### PR TITLE
feat: add cascade publish support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish to NPM
 
 on:
+  repository_dispatch:
+    types: [cascade-publish]
   workflow_dispatch:
     inputs:
       version-type:
@@ -21,6 +23,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.event_name == 'repository_dispatch' && 'cascade-update' || format('publish-{0}', github.ref) }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write
@@ -28,8 +34,18 @@ permissions:
 
 jobs:
   publish:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     uses: abofs/stonyx-workflows/.github/workflows/npm-publish.yml@main
     with:
       version-type: ${{ github.event.inputs.version-type }}
       custom-version: ${{ github.event.inputs.custom-version }}
+      cascade-source: ${{ github.event.client_payload.source_package || '' }}
+    secrets: inherit
+
+  cascade:
+    needs: publish
+    uses: abofs/stonyx-workflows/.github/workflows/cascade.yml@main
+    with:
+      package-name: ${{ needs.publish.outputs.package-name }}
+      published-version: ${{ needs.publish.outputs.published-version }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- Add `repository_dispatch` trigger and cascade job to `publish.yml` for automated downstream dependency updates
- Replace `file:../` references in `package.json` with real npm versions (latest beta pins)
- Regenerate `pnpm-lock.yaml` with npm registry versions

## Test plan
- [ ] `pnpm install` succeeds with npm versions
- [ ] CI tests pass on the PR
- [ ] Workflow YAML is valid (no syntax errors in Actions tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)