### PR TITLE
Return undefined instead of null for missing paths in get()

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -44,7 +44,7 @@ export function get(obj, path) {
   if (typeof path !== 'string') return console.error('The path provided to get must be a string.');
 
   for (const key of path.split('.')) {
-    if (obj[key] === undefined) return null;
+    if (obj[key] === undefined) return;
 
     obj = obj[key];
   }

--- a/test/unit/object/get-test.js
+++ b/test/unit/object/get-test.js
@@ -15,19 +15,19 @@ module('[Unit] Object | get', function() {
     assert.strictEqual(get(obj, 'a.b.c'), 42);
   });
 
-  test('returns null for missing top-level property', function(assert) {
+  test('returns undefined for missing top-level property', function(assert) {
     const obj = { a: 1 };
-    assert.strictEqual(get(obj, 'b'), null);
+    assert.strictEqual(get(obj, 'b'), undefined);
   });
 
-  test('returns null for missing nested property', function(assert) {
+  test('returns undefined for missing nested property', function(assert) {
     const obj = { a: { b: 2 } };
-    assert.strictEqual(get(obj, 'a.b.c'), null);
+    assert.strictEqual(get(obj, 'a.b.c'), undefined);
   });
 
-  test('returns null if path points to undefined property', function(assert) {
+  test('returns undefined if path points to undefined property', function(assert) {
     const obj = { a: { b: undefined } };
-    assert.strictEqual(get(obj, 'a.b'), null);
+    assert.strictEqual(get(obj, 'a.b'), undefined);
   });
 
   test('logs error if called with only one argument (failing case)', function(assert) {


### PR DESCRIPTION
## Summary
- `get()` now returns `undefined` instead of `null` when a path is missing or points to an undefined property
- This distinguishes "property not present in payload" from "property explicitly set to null", enabling downstream consumers (e.g. ORM serializer) to support null-clearing updates

## Test plan
- [x] Updated existing unit tests to assert `undefined` instead of `null`
- [ ] Verify stonyx-orm serializer correctly skips undefined (not-present) fields while allowing null through