### PR TITLE
fix: add explicit files whitelist for npm publish safety

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,10 @@
-# tests
-test/
-
-# config
-.nvmrc
-# git
 .git
+.env
+.npmrc
+.claude/
+.github/
+test/
+scripts/
+*.log
+.nvmrc
+.gitignore

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "url": "https://github.com/abofs/stonyx-utils.git"
   },
   "type": "module",
+  "files": [
+    "src",
+    "README.md"
+  ],
   "exports": {
     "./date": "./src/date.js",
     "./object": "./src/object.js",


### PR DESCRIPTION
## Summary
- Add explicit `files` whitelist (`src`, `README.md`) to `package.json` to control exactly what gets published to npm
- Replace minimal `.npmignore` with comprehensive exclusions (`.env`, `.npmrc`, `.claude/`, `.github/`, `test/`, `scripts/`, `*.log`, etc.)
- Verified with `npm pack --dry-run` that only intended files are included

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)