### PR TITLE
docs: establish documentation conventions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,3 @@
+# @stonyx/utils
+
+See [docs/index.md](../docs/index.md) for project documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# @stonyx/utils
+
+Utilities module for the Stonyx Framework. Provides helpers for files, objects, strings, dates, promises, and interactive CLI prompts.
+
+## Documentation
+
+- [README](../README.md) -- quick-reference table and full API docs
+- [Project structure](project-structure.md) -- file layout, module exports, dependencies, and test patterns
+- [Release instructions](release.md)

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -45,7 +45,11 @@
 ```
 stonyx-utils/
   .claude/                        # Claude project memory
+    CLAUDE.md                     # Agent entry point
+  docs/                           # Human-facing documentation
+    index.md                      # Documentation entry point
     project-structure.md          # This file
+    release.md                    # Release instructions
   .github/
     workflows/
       ci.yml                      # CI on PRs to dev/main (reusable workflow)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,3 @@
+# Release Instructions
+
+> Placeholder -- release process to be documented as part of onboarding.


### PR DESCRIPTION
## Summary
- Move `.claude/project-structure.md` to `docs/project-structure.md`
- Create `docs/index.md` as human-facing entry point indexing project-structure and linking to README
- Create `docs/release.md` as placeholder for release instructions
- Create `.claude/CLAUDE.md` as thin agent entry point referencing `docs/index.md`
- Update file structure diagram in project-structure.md to reflect new layout

## Context
Onboarding Step 3 -- establishing consistent documentation conventions across Stonyx repos.

## Test plan
- [ ] Verify `docs/index.md` renders correctly and links work
- [ ] Verify `.claude/CLAUDE.md` link to `docs/index.md` resolves
- [ ] Verify moved `project-structure.md` internal links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)