### PR TITLE
fix: improve type coverage from TS migration audit

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -4,12 +4,16 @@ import { objToJson } from './object.js';
 import { promises as fsp } from 'fs';
 import path from 'path';
 
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
 interface FileOptions {
   json?: boolean;
 }
 
 interface ReadFileOptions extends FileOptions {
-  missingFileCallback?: (filePath: string) => unknown;
+  missingFileCallback?: (filePath: string) => string | Record<string, unknown>;
 }
 
 interface DeleteFileOptions {
@@ -31,23 +35,23 @@ interface FileImportMeta {
   path: string;
 }
 
-export async function createFile(filePath: string, data: unknown, options: FileOptions = {}): Promise<void> {
+export async function createFile(filePath: string, data: string | Record<string, unknown>, options: FileOptions = {}): Promise<void> {
   try {
     filePath = path.resolve(filePath);
 
     await createDirectory(path.dirname(filePath));
-    await fsp.writeFile(filePath, options.json ? objToJson(data) : data as string, 'utf8');
+    await fsp.writeFile(filePath, options.json ? objToJson(data) : String(data), 'utf8');
   } catch (error) {
     throw new Error(String(error));
   }
 }
 
-export async function updateFile(filePath: string, data: unknown, options: FileOptions = {}): Promise<void> {
+export async function updateFile(filePath: string, data: string | Record<string, unknown>, options: FileOptions = {}): Promise<void> {
   try {
     await fsp.access(filePath);
 
     const swapFile = `${filePath}.temp-${getTimestamp()}`;
-    await fsp.writeFile(swapFile, options.json ? objToJson(data) : data as string);
+    await fsp.writeFile(swapFile, options.json ? objToJson(data) : String(data));
     await fsp.rename(swapFile, filePath);
   } catch (error) {
 
@@ -82,18 +86,20 @@ export async function copyFile(sourcePath: string, targetPath: string, options: 
   return true;
 }
 
-export async function readFile(filePath: string, options: ReadFileOptions = {}): Promise<unknown> {
+export async function readFile(filePath: string, options: ReadFileOptions & { json: true }): Promise<Record<string, unknown>>;
+export async function readFile(filePath: string, options?: ReadFileOptions): Promise<string>;
+export async function readFile(filePath: string, options: ReadFileOptions = {}): Promise<string | Record<string, unknown>> {
   try {
     filePath = path.resolve(filePath);
 
     await fsp.access(filePath);
     const fileData = await fsp.readFile(filePath, 'utf8');
 
-    return options.json ? JSON.parse(fileData) : fileData;
+    return options.json ? JSON.parse(fileData) as Record<string, unknown> : fileData;
   } catch (error) {
     const { missingFileCallback } = options;
 
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT' && missingFileCallback) {
+    if (isNodeError(error) && error.code === 'ENOENT' && missingFileCallback) {
       return missingFileCallback(filePath);
     }
 
@@ -122,7 +128,7 @@ export async function createDirectory(dir: string): Promise<void> {
   await fsp.mkdir(dir, { recursive: true });
 }
 
-export async function forEachFileImport(dir: string, callback: (output: unknown, meta: FileImportMeta) => void, options: ForEachFileImportOptions = {}): Promise<void> {
+export async function forEachFileImport(dir: string, callback: (output: unknown, meta: FileImportMeta) => void | Promise<void>, options: ForEachFileImportOptions = {}): Promise<void> {
   if (typeof callback !== 'function') throw new Error('Callback must be valid function');
 
   try {
@@ -170,7 +176,7 @@ export async function fileExists(filePath: string): Promise<boolean> {
     filePath = path.resolve(filePath);
     await fsp.access(filePath);
     return true;
-  } catch (error) {
+  } catch {
     return false;
   }
 }

--- a/src/object.ts
+++ b/src/object.ts
@@ -1,8 +1,10 @@
 export function deepCopy<T>(obj: T): T {
-  return JSON.parse(JSON.stringify(obj));
+  return JSON.parse(JSON.stringify(obj)) as T;
 }
 
-export function objToJson(obj: unknown, format: string | number = '\t'): string {
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+export function objToJson(obj: JsonValue | Record<string, unknown>, format: string | number = '\t'): string {
   return JSON.stringify(obj, null, format);
 }
 
@@ -43,7 +45,7 @@ export function mergeObject(obj1: Record<string, unknown>, obj2: Record<string, 
 }
 
 export function get(obj: Record<string, unknown>, path: string): unknown;
-export function get(obj: unknown, path?: unknown): void;
+export function get(obj: unknown, path?: unknown): undefined;
 export function get(obj: unknown, path?: unknown): unknown {
   if (arguments.length !== 2) return console.error('Get must be called with two arguments; an object and a property key.');
   if (!obj) return console.error(`Cannot call get with '${path}' on an undefined object.`);
@@ -51,9 +53,9 @@ export function get(obj: unknown, path?: unknown): unknown {
 
   let current: Record<string, unknown> = obj as Record<string, unknown>;
   for (const key of path.split('.')) {
-    if ((current as Record<string, unknown>)[key] === undefined) return;
+    if (current[key] === undefined) return;
 
-    current = (current as Record<string, unknown>)[key] as Record<string, unknown>;
+    current = current[key] as Record<string, unknown>;
   }
 
   return current;
@@ -62,7 +64,10 @@ export function get(obj: unknown, path?: unknown): unknown {
 export function getOrSet<K, V>(map: Map<K, V>, key: K, defaultValue: V | (() => V)): V {
   if (!(map instanceof Map)) throw new Error('First argument to getOrSet must be a Map.');
 
-  if (!map.has(key)) map.set(key, typeof defaultValue === "function" ? (defaultValue as () => V)() : defaultValue);
+  if (!map.has(key)) {
+    const value = typeof defaultValue === 'function' ? (defaultValue as () => V)() : defaultValue;
+    map.set(key, value);
+  }
 
-  return map.get(key)!;
+  return map.get(key) as V;
 }


### PR DESCRIPTION
## Summary
- **file.ts**: Replace `data: unknown` with `string | Record<string, unknown>` in `createFile`/`updateFile`, eliminating unsafe `as string` casts
- **file.ts**: Add function overloads to `readFile` so callers get `Record<string, unknown>` when `json: true` and `string` otherwise, instead of `unknown`
- **file.ts**: Add `isNodeError` type guard to replace `(error as NodeJS.ErrnoException)` cast in `readFile` catch block
- **file.ts**: Narrow `missingFileCallback` return type from `unknown` to `string | Record<string, unknown>`
- **file.ts**: Allow `forEachFileImport` callback to return `Promise<void>` for async callbacks
- **file.ts**: Remove unused `error` binding in `fileExists` catch block
- **object.ts**: Add `JsonValue` recursive type and apply it to `objToJson` parameter instead of `unknown`
- **object.ts**: Make `deepCopy` `JSON.parse` return explicit with `as T` instead of relying on implicit `any`
- **object.ts**: Fix `get()` error overload return type from `void` to `undefined` (matches `console.error` return)
- **object.ts**: Remove two redundant `as Record<string, unknown>` casts inside `get()` where `current` was already typed
- **object.ts**: Replace non-null assertion `map.get(key)!` with `as V` in `getOrSet` (guarded by preceding `has` + `set`)

Resolves abofs/stonyx-utils#22

## Test plan
- [x] `pnpm build` compiles cleanly with `strict: true`
- [x] All 71 existing tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)