### PR TITLE
fix: improve type coverage in test suite from migration audit

### DIFF
--- a/test/unit/file-test.ts
+++ b/test/unit/file-test.ts
@@ -38,7 +38,7 @@ module('[Unit] File', function(hooks) {
 
     test('creates a JSON file when option.json is true', async function(assert) {
       await createFile(TMP_JSON_FILE, { foo: 'bar' }, { json: true });
-      const data: Record<string, unknown> = JSON.parse(await fsp.readFile(TMP_JSON_FILE, 'utf8'));
+      const data = JSON.parse(await fsp.readFile(TMP_JSON_FILE, 'utf8')) as { foo: string };
       assert.deepEqual(data, { foo: 'bar' });
     });
   });
@@ -100,7 +100,7 @@ module('[Unit] File', function(hooks) {
 
     test('reads JSON', async function(assert) {
       await createFile(TMP_JSON_FILE, { foo: 'bar' }, { json: true });
-      const result: Record<string, unknown> = await readFile(TMP_JSON_FILE, { json: true });
+      const result = await readFile(TMP_JSON_FILE, { json: true }) as { foo: string };
       assert.deepEqual(result, { foo: 'bar' });
     });
 
@@ -164,7 +164,7 @@ module('[Unit] File', function(hooks) {
       const filePath: string = path.join(IMPORT_DIR, 'hello-world.js');
       await fsp.writeFile(filePath, 'export default "hello";', 'utf8');
 
-      let called = false;
+      let called: boolean = false;
       await forEachFileImport(IMPORT_DIR, (output, meta) => {
         called = true;
         assert.equal(output, 'hello');

--- a/test/unit/object/get-test.ts
+++ b/test/unit/object/get-test.ts
@@ -11,7 +11,7 @@ module('[Unit] Object | get', function() {
   });
 
   test('retrieves nested property', function(assert) {
-    const obj = { a: { b: { c: 42 } } };
+    const obj: Record<string, Record<string, Record<string, number>>> = { a: { b: { c: 42 } } };
     assert.strictEqual(get(obj, 'a.b.c'), 42);
   });
 
@@ -21,12 +21,12 @@ module('[Unit] Object | get', function() {
   });
 
   test('returns undefined for missing nested property', function(assert) {
-    const obj = { a: { b: 2 } };
+    const obj: Record<string, Record<string, number>> = { a: { b: 2 } };
     assert.strictEqual(get(obj, 'a.b.c'), undefined);
   });
 
   test('returns undefined if path points to undefined property', function(assert) {
-    const obj = { a: { b: undefined } };
+    const obj: Record<string, Record<string, undefined>> = { a: { b: undefined } };
     assert.strictEqual(get(obj, 'a.b'), undefined);
   });
 

--- a/test/unit/object/getOrSet-test.ts
+++ b/test/unit/object/getOrSet-test.ts
@@ -19,9 +19,9 @@ module('[Unit] Object | getOrSet', function() {
   });
 
   test('sets and returns default value when key is missing (function default)', function(assert) {
-    const map = new Map<string, Map<string, unknown>>();
-    const defaultFactory = sinon.stub().returns(new Map<string, unknown>());
-    const result: Map<string, unknown> = getOrSet(map, 'nested', defaultFactory);
+    const map = new Map<string, Map<string, string>>();
+    const defaultFactory = sinon.stub().returns(new Map<string, string>());
+    const result: Map<string, string> = getOrSet(map, 'nested', defaultFactory);
 
     assert.ok(result instanceof Map, 'Factory should create a Map');
     assert.strictEqual(map.get('nested'), result, 'Created value should be stored in map');

--- a/test/unit/object/object-test.ts
+++ b/test/unit/object/object-test.ts
@@ -31,13 +31,11 @@ module('[Unit] Object | mergeObject', function() {
   });
 
   test('does not share references (copy-safe)', async function(assert) {
-    const source1 = { a: { nested: 1 } };
-    const source2 = { b: { nested: 2 } };
+    interface Nested { nested: number }
+    const source1: Record<string, Nested> = { a: { nested: 1 } };
+    const source2: Record<string, Nested> = { b: { nested: 2 } };
 
-    const result = mergeObject(source1, source2) as {
-      a: { nested: number };
-      b: { nested: number };
-    };
+    const result = mergeObject(source1, source2) as Record<string, Nested>;
 
     // Mutate result
     result.a.nested = 99;
@@ -51,7 +49,7 @@ module('[Unit] Object | mergeObject', function() {
     const obj1: Record<string, number> = { a: 1, b: 2 };
     const obj2: Record<string, number> = { b: 3, c: 4 };
 
-    const result = mergeObject(obj1, obj2, { ignoreNewKeys: true });
+    const result: Record<string, unknown> = mergeObject(obj1, obj2, { ignoreNewKeys: true });
 
     assert.deepEqual(
       result,
@@ -61,10 +59,10 @@ module('[Unit] Object | mergeObject', function() {
   });
 
   test('ignores new keys recursively when ignoreNewKeys is true', async function(assert) {
-    const obj1 = { a: { x: 1, y: 2 } };
-    const obj2 = { a: { y: 3, z: 4 } };
+    const obj1: Record<string, Record<string, number>> = { a: { x: 1, y: 2 } };
+    const obj2: Record<string, Record<string, number>> = { a: { y: 3, z: 4 } };
 
-    const result = mergeObject(obj1, obj2, { ignoreNewKeys: true });
+    const result: Record<string, unknown> = mergeObject(obj1, obj2, { ignoreNewKeys: true });
 
     assert.deepEqual(
       result,


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` with specific shapes (e.g. `{ foo: string }`) where test data is known, reducing reliance on loose types
- Add missing explicit type annotations on test variables (`called: boolean`, nested `Record` types for `get` test objects, `mergeObject` results)
- Narrow `Map<string, unknown>` to `Map<string, string>` in `getOrSet` tests where the inner type is deterministic
- Replace inline ad-hoc type assertion casts with interface-backed `Record` types in `mergeObject` copy-safety test

Closes #24

## Test plan
- [x] `pnpm build` compiles cleanly
- [x] `pnpm build:test` compiles cleanly
- [x] `pnpm test` — all 71 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)