### PR TITLE
feat: add FuzzyMatch utility for cross-source string reconciliation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
     "./string": {
       "types": "./dist/string.d.ts",
       "default": "./dist/string.js"
+    },
+    "./fuzzy-match": {
+      "types": "./dist/fuzzy-match.d.ts",
+      "default": "./dist/fuzzy-match.js"
     }
   },
   "scripts": {

--- a/src/fuzzy-match.ts
+++ b/src/fuzzy-match.ts
@@ -1,0 +1,102 @@
+/**
+ * Generic fuzzy string matching for cross-source reconciliation.
+ * Handles Unicode normalization, stop-word filtering, and word-set similarity scoring.
+ */
+
+export interface FuzzyMatchOptions {
+  stopWords?: string[];
+  delimiter?: string;
+  threshold?: number;
+}
+
+export interface FuzzyMatchResult<T extends { name: string }> {
+  entry: T;
+  score: number;
+}
+
+function normalizeString(name: string, stopWords: string[] = []): string {
+  let result = name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ');
+
+  if (stopWords.length) {
+    const pattern = new RegExp(`\\b(${stopWords.join('|')})\\b`, 'g');
+    result = result.replace(pattern, '');
+  }
+
+  return result.replace(/\s+/g, ' ').trim();
+}
+
+function wordSet(normalized: string): Set<string> {
+  return new Set(normalized.split(' ').filter(w => w.length > 1));
+}
+
+export default class FuzzyMatch {
+  stopWords: string[];
+  delimiter: string;
+  threshold: number;
+
+  constructor(options: FuzzyMatchOptions = {}) {
+    this.stopWords = options.stopWords || [];
+    this.delimiter = options.delimiter || '\u00B7';
+    this.threshold = options.threshold || 0.35;
+  }
+
+  normalize(name: string): string {
+    return normalizeString(name, this.stopWords);
+  }
+
+  similarity(nameA: string, nameB: string): number {
+    const aN = this.normalize(nameA);
+    const sN = this.normalize(nameB);
+
+    if (!aN || !sN) return 0;
+    if (aN === sN) return 1.0;
+    if (aN.includes(sN) || sN.includes(aN)) return 0.9;
+
+    const aWords = wordSet(aN);
+    const sWords = wordSet(sN);
+    if (aWords.size === 0 || sWords.size === 0) return 0;
+
+    let overlap = 0;
+    for (const w of aWords) {
+      if (sWords.has(w)) {
+        overlap++;
+      } else {
+        for (const sw of sWords) {
+          if (sw.startsWith(w) || w.startsWith(sw)) {
+            overlap += 0.7;
+            break;
+          }
+        }
+      }
+    }
+
+    return overlap / Math.max(aWords.size, sWords.size);
+  }
+
+  findBestMatch<T extends { name: string }>(nameA: string, nameB: string, entries: T[], threshold?: number): FuzzyMatchResult<T> | null {
+    const minScore = threshold ?? this.threshold;
+    let bestMatch: T | null = null;
+    let bestScore = 0;
+
+    for (const entry of entries) {
+      const parts = entry.name.split(this.delimiter);
+      if (parts.length !== 2) continue;
+
+      const [entryA, entryB] = parts;
+      const normalScore = (this.similarity(nameA, entryA) + this.similarity(nameB, entryB)) / 2;
+      const reversedScore = (this.similarity(nameA, entryB) + this.similarity(nameB, entryA)) / 2;
+      const score = Math.max(normalScore, reversedScore);
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestMatch = entry;
+      }
+    }
+
+    return bestScore >= minScore && bestMatch ? { entry: bestMatch, score: bestScore } : null;
+  }
+}

--- a/test/unit/fuzzy-match-test.ts
+++ b/test/unit/fuzzy-match-test.ts
@@ -1,0 +1,178 @@
+import QUnit from 'qunit';
+import FuzzyMatch from '@stonyx/utils/fuzzy-match';
+
+const { module, test } = QUnit;
+
+module('[Unit] FuzzyMatch | normalize', function() {
+  test('lowercases and strips accents', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.normalize('Atlético Madrid'), 'atletico madrid');
+  });
+
+  test('removes special characters', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.normalize('FC Bayern (München)'), 'fc bayern munchen');
+  });
+
+  test('collapses whitespace', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.normalize('  Real   Madrid  '), 'real madrid');
+  });
+
+  test('filters stop words', function(assert) {
+    const fm = new FuzzyMatch({ stopWords: ['fc', 'sc'] });
+    assert.strictEqual(fm.normalize('FC Barcelona'), 'barcelona');
+    assert.strictEqual(fm.normalize('SC Freiburg'), 'freiburg');
+  });
+
+  test('returns empty string for empty input', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.normalize(''), '');
+  });
+});
+
+module('[Unit] FuzzyMatch | similarity', function() {
+  test('exact match returns 1.0', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.similarity('Real Madrid', 'Real Madrid'), 1.0);
+  });
+
+  test('case-insensitive exact match returns 1.0', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.similarity('real madrid', 'REAL MADRID'), 1.0);
+  });
+
+  test('accent-insensitive exact match returns 1.0', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.similarity('Atlético', 'Atletico'), 1.0);
+  });
+
+  test('substring match returns 0.9', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.similarity('Manchester United FC', 'Manchester United'), 0.9);
+  });
+
+  test('empty string returns 0', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.similarity('', 'test'), 0);
+    assert.strictEqual(fm.similarity('test', ''), 0);
+  });
+
+  test('no common words returns 0', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.similarity('Barcelona', 'Liverpool'), 0);
+  });
+
+  test('partial word overlap via prefix returns fractional score', function(assert) {
+    const fm = new FuzzyMatch();
+    const score = fm.similarity('Man Utd', 'Manchester United');
+    assert.ok(score > 0 && score < 1, `expected fractional score, got ${score}`);
+  });
+
+  test('word overlap produces meaningful score', function(assert) {
+    const fm = new FuzzyMatch();
+    const score = fm.similarity('Real Madrid CF', 'Real Madrid');
+    assert.ok(score > 0.5, `expected high score, got ${score}`);
+  });
+});
+
+module('[Unit] FuzzyMatch | findBestMatch', function() {
+  const entries = [
+    { name: 'Real Madrid·FC Barcelona', id: 1 },
+    { name: 'Liverpool·Manchester City', id: 2 },
+    { name: 'Bayern München·Borussia Dortmund', id: 3 },
+  ];
+
+  test('finds exact pair match', function(assert) {
+    const fm = new FuzzyMatch();
+    const result = fm.findBestMatch('Real Madrid', 'FC Barcelona', entries);
+    assert.ok(result !== null);
+    assert.strictEqual(result!.entry.id, 1);
+    assert.ok(result!.score >= 0.9);
+  });
+
+  test('finds reversed pair match', function(assert) {
+    const fm = new FuzzyMatch();
+    const result = fm.findBestMatch('FC Barcelona', 'Real Madrid', entries);
+    assert.ok(result !== null);
+    assert.strictEqual(result!.entry.id, 1);
+  });
+
+  test('returns null when no match above threshold', function(assert) {
+    const fm = new FuzzyMatch();
+    const result = fm.findBestMatch('PSG', 'Marseille', entries);
+    assert.strictEqual(result, null);
+  });
+
+  test('respects custom threshold', function(assert) {
+    const fm = new FuzzyMatch({ threshold: 0.99 });
+    const result = fm.findBestMatch('Real Madrid', 'Barcelona', entries);
+    assert.strictEqual(result, null);
+  });
+
+  test('per-call threshold overrides instance threshold', function(assert) {
+    const fm = new FuzzyMatch({ threshold: 0.01 });
+    const result = fm.findBestMatch('PSG', 'Marseille', entries, 0.99);
+    assert.strictEqual(result, null);
+  });
+
+  test('skips entries without exactly 2 parts', function(assert) {
+    const fm = new FuzzyMatch();
+    const badEntries = [{ name: 'Only One Team', id: 99 }];
+    const result = fm.findBestMatch('Only', 'One Team', badEntries);
+    assert.strictEqual(result, null);
+  });
+
+  test('handles accent normalization in matching', function(assert) {
+    const fm = new FuzzyMatch();
+    const result = fm.findBestMatch('Bayern Munchen', 'Borussia Dortmund', entries);
+    assert.ok(result !== null);
+    assert.strictEqual(result!.entry.id, 3);
+  });
+
+  test('works with custom delimiter', function(assert) {
+    const fm = new FuzzyMatch({ delimiter: ' vs ' });
+    const customEntries = [{ name: 'Chelsea vs Arsenal', id: 10 }];
+    const result = fm.findBestMatch('Chelsea', 'Arsenal', customEntries);
+    assert.ok(result !== null);
+    assert.strictEqual(result!.entry.id, 10);
+  });
+
+  test('returns empty for empty entries array', function(assert) {
+    const fm = new FuzzyMatch();
+    const result = fm.findBestMatch('A', 'B', []);
+    assert.strictEqual(result, null);
+  });
+
+  test('preserves generic entry type in result', function(assert) {
+    const fm = new FuzzyMatch();
+    const typedEntries = [{ name: 'Real Madrid·FC Barcelona', id: 1, extra: 'data' }];
+    const result = fm.findBestMatch('Real Madrid', 'FC Barcelona', typedEntries);
+    assert.ok(result !== null);
+    assert.strictEqual(result!.entry.extra, 'data');
+  });
+});
+
+module('[Unit] FuzzyMatch | constructor defaults', function() {
+  test('default threshold is 0.35', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.threshold, 0.35);
+  });
+
+  test('default delimiter is middle dot', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.strictEqual(fm.delimiter, '\u00B7');
+  });
+
+  test('default stopWords is empty', function(assert) {
+    const fm = new FuzzyMatch();
+    assert.deepEqual(fm.stopWords, []);
+  });
+
+  test('accepts custom options', function(assert) {
+    const fm = new FuzzyMatch({ stopWords: ['fc'], delimiter: '|', threshold: 0.5 });
+    assert.deepEqual(fm.stopWords, ['fc']);
+    assert.strictEqual(fm.delimiter, '|');
+    assert.strictEqual(fm.threshold, 0.5);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `FuzzyMatch` class to `@stonyx/utils/fuzzy-match` with Unicode normalization, stop-word filtering, word-set similarity scoring, and configurable best-match finding
- TypeScript conversion of reference implementation from `nextgoal-data-collector/utils/fuzzy-match.js` (~80 LOC)
- Generic `findBestMatch<T>()` preserves entry type through the result
- 27 unit tests covering normalize, similarity, findBestMatch, and constructor defaults

Closes abofs/stonyx#42

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `pnpm test` — 98/98 passing (27 new + 71 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)