### PR TITLE
chore: add prompts to README utility tagline (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # stonyx-utils
 
-Utilities module for the Stonyx Framework. Provides helpers for files, objects, strings, dates, and promises.
+Utilities module for the Stonyx Framework. Provides helpers for files, objects, strings, dates, promises, and prompts.
 
 ---
 


### PR DESCRIPTION
## Summary

- One-line README correction: adds `prompts` to the utility tagline, matching the Quick Reference Table which already documents Prompt utilities (`confirm`, `prompt`)
- Triggers the stonyx-workflows cascade pipeline to refresh all downstream beta versions
- Closes #34

## Rationale

After Sprints 42 + 43, all Stonyx repos are clean (zero open PRs/issues). A minimal doc change here triggers the cascade, aligning every Stonyx repo on fresh matching betas as preamble to a stable stonyx release.

## Test Plan

- [x] Local diff verified — single-line semantic doc correction, not whitespace-only
- [ ] CI green on PR
- [ ] Post-merge: \`npm view @stonyx/utils dist-tags.beta\` shows new beta
- [ ] Post-merge: stonyx-workflows cascade-publish workflow fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)