### PR TITLE
fix: forEachFileImport now accepts .ts files (#36)

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -158,10 +158,10 @@ export async function forEachFileImport(dir: string, callback: (output: unknown,
       continue;
     }
 
-    if (!stats.isFile() || !file.endsWith('.js')) continue;
+    if (!stats.isFile() || !(file.endsWith('.js') || file.endsWith('.ts'))) continue;
 
     const prefix = process.platform === 'win32' ? 'file://' : '';
-    const rawName = file.replace('.js', '');
+    const rawName = file.replace(/\.(js|ts)$/, '');
     let name = options.rawName ? rawName : kebabCaseToCamelCase(rawName);
 
     if (options.namePrefix) name = `${options.namePrefix}${name}`;

--- a/test/unit/file-test.ts
+++ b/test/unit/file-test.ts
@@ -174,6 +174,20 @@ module('[Unit] File', function(hooks) {
       assert.ok(called);
     });
 
+    test('calls callback for each .ts file', async function(assert) {
+      const filePath: string = path.join(IMPORT_DIR, 'ts-sample.ts');
+      await fsp.writeFile(filePath, 'export default "from-ts";', 'utf8');
+
+      let called: boolean = false;
+      await forEachFileImport(IMPORT_DIR, (output, meta) => {
+        called = true;
+        assert.equal(output, 'from-ts');
+        assert.equal(meta.name, 'tsSample');
+      });
+
+      assert.ok(called);
+    });
+
     test('returns when directory missing with ignoreAccessFailure', async function(assert) {
       const missingDir: string = path.join(IMPORT_DIR, 'does-not-exist');
       await forEachFileImport(missingDir, () => {


### PR DESCRIPTION
## Summary
- Extends `forEachFileImport` filter to accept `.ts` in addition to `.js`
- Updates `rawName` to strip either extension
- Adds unit test covering `.ts` path

## Why
Stonyx Sprint 45's TS-everywhere push migrated consumer test fixtures to `.ts`. The loader silently dropped them, causing downstream modules (stonyx-orm) to run with no models registered. Under tsx the `.ts` import resolves; in production compiled consumers only have `.js`, so this is a no-op there.

Closes #36. Unblocks stonyx-orm#114 (Sprint 45 B3).

## Test plan
- [x] `pnpm test` → 99/99 pass (incl. new `.ts` coverage)
- [ ] CI green
- [ ] Consumer verification: stonyx-orm test suite goes from 157 fail → 0 fail after utils bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)