### PR TITLE
docs: drop "pure JavaScript" qualifier from Overview

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -22,7 +22,7 @@
 
 ## Overview
 
-`@stonyx/utils` is a utilities module for the Stonyx Framework. It provides pure JavaScript helper functions for file system operations, object manipulation, string transformations, date handling, promises, and interactive CLI prompts.
+`@stonyx/utils` is a utilities module for the Stonyx Framework. It provides helper functions for file system operations, object manipulation, string transformations, date handling, promises, and interactive CLI prompts.
 
 - **Package name:** `@stonyx/utils`
 - **Version:** see `package.json`


### PR DESCRIPTION
## Summary

Strips `pure JavaScript` from the Overview prose in `docs/project-structure.md`. Stonyx family no longer promotes source language in module docs — the intent is to drop the qualifier entirely rather than swap to "TypeScript".

Refs abofs/stonyx#77 (umbrella).

## Validation (Tier-1, ephemeral)

- `grep -n 'pure JavaScript' docs/project-structure.md` → zero matches ✅
- `grep -n -E '(100%|pure)\s*JavaScript' docs/project-structure.md` → zero matches ✅

## Test plan

- [x] Doc renders on GitHub with Overview sentence grammatical and complete
- [x] No behavioral code changes (doc-only)