### PR TITLE
feat: add deleteFileSync, stream factories, and binary buffer reads (#39)

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -1,6 +1,7 @@
 import { getTimestamp } from './date.js';
 import { kebabCaseToCamelCase } from './string.js';
 import { objToJson } from './object.js';
+import fs from 'fs';
 import { promises as fsp } from 'fs';
 import path from 'path';
 
@@ -14,6 +15,7 @@ interface FileOptions {
 
 interface ReadFileOptions extends FileOptions {
   missingFileCallback?: (filePath: string) => string | Record<string, unknown>;
+  encoding?: BufferEncoding | null;
 }
 
 interface DeleteFileOptions {
@@ -88,16 +90,20 @@ export async function copyFile(sourcePath: string, targetPath: string, options: 
   return true;
 }
 
+export async function readFile(filePath: string, options: ReadFileOptions & { encoding: null }): Promise<Buffer>;
 export async function readFile(filePath: string, options: ReadFileOptions & { json: true }): Promise<Record<string, unknown>>;
 export async function readFile(filePath: string, options?: ReadFileOptions): Promise<string>;
-export async function readFile(filePath: string, options: ReadFileOptions = {}): Promise<string | Record<string, unknown>> {
+export async function readFile(filePath: string, options: ReadFileOptions = {}): Promise<string | Buffer | Record<string, unknown>> {
   try {
     filePath = path.resolve(filePath);
 
     await fsp.access(filePath);
-    const fileData = await fsp.readFile(filePath, 'utf8');
+    const encoding = options.encoding === undefined ? 'utf8' : options.encoding;
+    const fileData = await fsp.readFile(filePath, { encoding: encoding as BufferEncoding | null });
 
-    return options.json ? JSON.parse(fileData) as Record<string, unknown> : fileData;
+    if (encoding === null) return fileData as Buffer;
+    if (options.json) return JSON.parse(fileData as string) as Record<string, unknown>;
+    return fileData as string;
   } catch (error) {
     const { missingFileCallback } = options;
 
@@ -122,12 +128,31 @@ export async function deleteFile(filePath: string, options?: DeleteFileOptions):
   await fsp.unlink(filePath);
 }
 
+export function deleteFileSync(filePath: string, options?: DeleteFileOptions): void {
+  try {
+    filePath = path.resolve(filePath);
+    fs.accessSync(filePath);
+  } catch (error) {
+    if (options?.ignoreAccessFailure) return;
+    throw error;
+  }
+  fs.unlinkSync(filePath);
+}
+
 export async function deleteDirectory(dir: string): Promise<void> {
   await fsp.rm(dir, { recursive: true, force: true });
 }
 
 export async function createDirectory(dir: string): Promise<void> {
   await fsp.mkdir(dir, { recursive: true });
+}
+
+export function createReadStream(filePath: string, options?: Parameters<typeof fs.createReadStream>[1]): fs.ReadStream {
+  return fs.createReadStream(path.resolve(filePath), options);
+}
+
+export function createWriteStream(filePath: string, options?: Parameters<typeof fs.createWriteStream>[1]): fs.WriteStream {
+  return fs.createWriteStream(path.resolve(filePath), options);
 }
 
 export async function forEachFileImport(dir: string, callback: (output: unknown, meta: FileImportMeta) => void | Promise<void>, options: ForEachFileImportOptions = {}): Promise<void> {

--- a/test/unit/file-test.ts
+++ b/test/unit/file-test.ts
@@ -7,8 +7,11 @@ import {
   copyFile,
   readFile,
   deleteFile,
+  deleteFileSync,
   deleteDirectory,
   createDirectory,
+  createReadStream,
+  createWriteStream,
   forEachFileImport,
   fileExists
 } from '@stonyx/utils/file';
@@ -110,6 +113,20 @@ module('[Unit] File', function(hooks) {
       });
       assert.equal(result, 'fallback');
     });
+
+    test('reads as Buffer when encoding is null', async function(assert) {
+      await createFile(TMP_FILE, 'binary-test');
+      const result = await readFile(TMP_FILE, { encoding: null });
+      assert.ok(Buffer.isBuffer(result), 'result is a Buffer');
+      assert.equal(result.toString('utf8'), 'binary-test', 'buffer contents match');
+    });
+
+    test('still returns string without encoding option (regression)', async function(assert) {
+      await createFile(TMP_FILE, 'text-test');
+      const result = await readFile(TMP_FILE);
+      assert.equal(typeof result, 'string', 'result is a string');
+      assert.equal(result, 'text-test');
+    });
   });
 
   module('deleteFile', function() {
@@ -126,6 +143,28 @@ module('[Unit] File', function(hooks) {
 
     test('ignores access failure when option set', async function(assert) {
       await deleteFile(TMP_FILE, { ignoreAccessFailure: true });
+      assert.ok(true, 'did not throw');
+    });
+  });
+
+  module('deleteFileSync', function() {
+    test('deletes an existing file synchronously', async function(assert) {
+      await createFile(TMP_FILE, 'data');
+      deleteFileSync(TMP_FILE);
+      try {
+        await fsp.access(TMP_FILE);
+        assert.ok(false, 'file should not exist');
+      } catch {
+        assert.ok(true);
+      }
+    });
+
+    test('throws when file does not exist', function(assert) {
+      assert.throws(() => deleteFileSync(TMP_FILE), 'throws for missing file');
+    });
+
+    test('ignores access failure when option set', function(assert) {
+      deleteFileSync(TMP_FILE, { ignoreAccessFailure: true });
       assert.ok(true, 'did not throw');
     });
   });
@@ -150,6 +189,32 @@ module('[Unit] File', function(hooks) {
       await createDirectory(deepDir);
       const stat = await fsp.stat(deepDir);
       assert.ok(stat.isDirectory());
+    });
+  });
+
+  module('createReadStream', function() {
+    test('returns a readable stream that yields file contents', async function(assert) {
+      await createFile(TMP_FILE, 'stream-data');
+      const stream = createReadStream(TMP_FILE, { encoding: 'utf8' });
+      const chunks: string[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk as string);
+      }
+      assert.equal(chunks.join(''), 'stream-data');
+    });
+  });
+
+  module('createWriteStream', function() {
+    test('returns a writable stream that creates file with data', async function(assert) {
+      const done = assert.async();
+      const stream = createWriteStream(TMP_FILE);
+      stream.write('written-data');
+      stream.end(() => {
+        fsp.readFile(TMP_FILE, 'utf8').then((data) => {
+          assert.equal(data, 'written-data');
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- **`deleteFileSync`** — synchronous version of `deleteFile` using `fs.accessSync` / `fs.unlinkSync`, with the same `ignoreAccessFailure` option
- **`createReadStream` / `createWriteStream`** — thin wrappers over `fs.createReadStream` / `fs.createWriteStream` that resolve the file path
- **Binary buffer reads** — added `encoding` option to `ReadFileOptions`; passing `{ encoding: null }` makes `readFile` return a `Buffer` instead of a string

All four additions include unit tests (7 new test cases). Build and full test suite pass.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)